### PR TITLE
Implement MultiThreadedCache.jl 

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,6 +14,7 @@ jobs:
       matrix:
         version:
           - '1.3'
+          - '1'
           - 'nightly'
         os:
           - ubuntu-latest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,47 @@
+name: CI
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+    tags: '*'
+jobs:
+  test:
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - '1.3'
+          - 'nightly'
+        os:
+          - ubuntu-latest
+        arch:
+          - x64
+    env:
+      matrix:
+        - JULIA_NUM_THREADS=1
+        - JULIA_NUM_THREADS=6
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: ${{ matrix.version }}
+          arch: ${{ matrix.arch }}
+      - uses: actions/cache@v1
+        env:
+          cache-name: cache-artifacts
+        with:
+          path: ~/.julia/artifacts
+          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-test-${{ env.cache-name }}-
+            ${{ runner.os }}-test-
+            ${{ runner.os }}-
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-runtest@v1
+      - uses: julia-actions/julia-processcoverage@v1
+      - uses: codecov/codecov-action@v1
+        with:
+          file: lcov.info

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,6 +18,8 @@ jobs:
           - 'nightly'
         os:
           - ubuntu-latest
+          - macOS-latest
+          - windows-latest
         arch:
           - x64
         env:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,10 +19,9 @@ jobs:
           - ubuntu-latest
         arch:
           - x64
-    env:
-      matrix:
-        - JULIA_NUM_THREADS=1
-        - JULIA_NUM_THREADS=6
+        env:
+          - JULIA_NUM_THREADS=1
+          - JULIA_NUM_THREADS=6
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1

--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -1,0 +1,16 @@
+name: CompatHelper
+on:
+  schedule:
+    - cron: 0 0 * * *
+  workflow_dispatch:
+jobs:
+  CompatHelper:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Pkg.add("CompatHelper")
+        run: julia -e 'using Pkg; Pkg.add("CompatHelper")'
+      - name: CompatHelper.main()
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMPATHELPER_PRIV: ${{ secrets.DOCUMENTER_KEY }}
+        run: julia -e 'using CompatHelper; CompatHelper.main()'

--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -1,0 +1,15 @@
+name: TagBot
+on:
+  issue_comment:
+    types:
+      - created
+  workflow_dispatch:
+jobs:
+  TagBot:
+    if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: JuliaRegistries/TagBot@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          ssh: ${{ secrets.DOCUMENTER_KEY }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/Manifest.toml

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 Nathan Daly <nhdaly@gmail.com> and contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,13 @@
+name = "MultiThreadedCaches"
+uuid = "18056a9e-ed0c-4ef3-9ad7-376a7fb08032"
+authors = ["Nathan Daly <nhdaly@gmail.com> and contributors"]
+version = "0.1.0"
+
+[compat]
+julia = "1.3"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+# MultiThreadedCaches

--- a/src/MultiThreadedCaches.jl
+++ b/src/MultiThreadedCaches.jl
@@ -6,11 +6,19 @@ export MultiThreadedCache, init_cache!
 
 struct MultiThreadedCache{K,V}
     thread_caches::Vector{Dict{K,V}}
-    base_cache::Dict{K,V}
+
+    base_cache::Dict{K,V}  # Guarded by: base_cache_lock
+    base_cache_lock::ReentrantLock
+    base_cache_futures::Dict{K,Channel{V}}  # Guarded by: base_cache_lock
 
     function MultiThreadedCache{K,V}() where {K,V}
+        thread_caches = Dict{K,V}[]
+
         base_cache = Dict{K,V}()
-        return new(Dict{K,V}[], base_cache)
+        base_cache_lock = ReentrantLock()
+        base_cache_futures = Dict{K,Channel{V}}()
+
+        return new(thread_caches, base_cache, base_cache_lock, base_cache_futures)
     end
 end
 
@@ -23,6 +31,7 @@ number of threads are set *at runtime, not precompilation time*.
 function init_cache!(cache::MultiThreadedCache{K,V}) where {K,V}
     append!(empty!(cache.thread_caches),
         Dict{K,V}[Dict{K,V}() for _ in 1:Threads.nthreads()])
+    return nothing
 end
 
 # Based upon the thread-safe Global RNG implementation in the Random stdlib:
@@ -39,7 +48,52 @@ function _thread_cache(cache::MultiThreadedCache)
     end
     return cache
 end
-@noinline _thread_cache_length_assert() = @assert false "length(cache.thread_caches) < Threads.nthreads() - Must call `init!(cache)` in Module __init__()."
+@noinline _thread_cache_length_assert() = @assert false "length(cache.thread_caches) < Threads.nthreads() - Must call `init_cache!(cache)` in Module __init__()."
+
+
+const CACHE_MISS = :__MultiThreadedCaches_key_not_found__
+
+function Base.get!(func::Base.Callable, cache::MultiThreadedCache{K,V}, key) where {K,V}
+    # If the thread-local cache has the value, we can return immediately.
+    # If not, we need to check the base cache.
+    return get!(_thread_cache(cache), key) do
+        # Even though we're using Thread-local caches, we still need to lock during
+        # construction to prevent multiple tasks redundantly constructing the same object,
+        # and potential thread safety violations due to Tasks migrating threads.
+        # NOTE that we only grab the lock if the key doesn't exist, so the mutex contention
+        # is not on the critical path for most accessses. :)
+        is_first_task = false
+        local future  # used only if the base_cache doesn't have the key
+        # We lock the mutex, but for only a short, *constant time* duration, to grab the
+        # future for this key, or to create the future if it doesn't exist.
+        @lock cache.base_cache_lock begin
+            value_or_miss = get(cache.base_cache, key, CACHE_MISS)
+            if value_or_miss !== CACHE_MISS
+                return value_or_miss::V
+            end
+            future = get!(cache.base_cache_futures, key) do
+                is_first_task = true
+                Channel{V}(1)
+            end
+        end
+        if is_first_task
+            v = func()
+            # Finally, lock again for a *constant time* to insert the computed value into
+            # the shared cache, so that we can free the Channel and future gets can read
+            # from the shared base_cache.
+            @lock cache.base_cache_lock begin
+                cache.base_cache[key] = v
+            end
+            # Return v to any other Tasks that were blocking on this key.
+            put!(future, v)
+            return v
+        else
+            # Block on the future until the first task that asked for this key finishes
+            # computing a value for it.
+            return fetch(future)
+        end
+    end
+end
 
 
 end # module

--- a/src/MultiThreadedCaches.jl
+++ b/src/MultiThreadedCaches.jl
@@ -1,0 +1,45 @@
+module MultiThreadedCaches
+
+using Base: @lock
+
+export MultiThreadedCache, init_cache!
+
+struct MultiThreadedCache{K,V}
+    thread_caches::Vector{Dict{K,V}}
+    base_cache::Dict{K,V}
+
+    function MultiThreadedCache{K,V}() where {K,V}
+        base_cache = Dict{K,V}()
+        return new(Dict{K,V}[], base_cache)
+    end
+end
+
+"""
+    init_cache!(cache::MultiThreadedCache{K,V})
+
+This function must be called inside a Module's `__init__()` method, to ensure that the
+number of threads are set *at runtime, not precompilation time*.
+"""
+function init_cache!(cache::MultiThreadedCache{K,V}) where {K,V}
+    append!(empty!(cache.thread_caches),
+        Dict{K,V}[Dict{K,V}() for _ in 1:Threads.nthreads()])
+end
+
+# Based upon the thread-safe Global RNG implementation in the Random stdlib:
+# https://github.com/JuliaLang/julia/blob/e4fcdf5b04fd9751ce48b0afc700330475b42443/stdlib/Random/src/RNGs.jl#L369-L385
+# Get or lazily construct the per-thread cache when first requested.
+function _thread_cache(cache::MultiThreadedCache)
+    length(cache.thread_caches) >= Threads.nthreads() || _thread_cache_length_assert()
+    tid = Threads.threadid()
+    if @inbounds isassigned(cache.thread_caches, tid)
+        @inbounds cache = cache.thread_caches[tid]
+    else
+        cache = eltype(cache.thread_caches)()
+        @inbounds cache.thread_caches[tid] = cache
+    end
+    return cache
+end
+@noinline _thread_cache_length_assert() = @assert false "length(cache.thread_caches) < Threads.nthreads() - Must call `init!(cache)` in Module __init__()."
+
+
+end # module

--- a/src/MultiThreadedCaches.jl
+++ b/src/MultiThreadedCaches.jl
@@ -151,7 +151,9 @@ function Base.get!(func::Base.Callable, cache::MultiThreadedCache{K,V}, key) whe
                 e isa Exception || (e = ErrorException("Non-exception object thrown during get!(): $e"))
                 close(future, e)
                 # As below, the future isn't needed after this returns (see below).
-                delete!(cache.base_cache_futures, key)
+                @lock cache.base_cache_lock begin
+                    delete!(cache.base_cache_futures, key)
+                end
                 rethrow(e)
             end
             # Finally, lock again for a *constant time* to insert the computed value into

--- a/test/MultiThreadedCaches.jl
+++ b/test/MultiThreadedCaches.jl
@@ -1,0 +1,15 @@
+using MultiThreadedCaches
+
+using Test
+
+@testset "basics" begin
+
+    cache = MultiThreadedCache{Int,Int}()
+    init_cache!(cache)
+
+    @test length(cache.thread_caches) == Threads.nthreads()
+
+
+
+end
+

--- a/test/MultiThreadedCaches.jl
+++ b/test/MultiThreadedCaches.jl
@@ -72,5 +72,17 @@ end
     @test length(cache.base_cache_futures) == 0
 end
 
+@testset "constructors" begin
+    # Constructing with precomputed cache key/value pairs:
+    cache = MultiThreadedCache{Int64, Int64}(Dict(2 => 3, 1 => 2))
+    init_cache!(cache)
+
+    # Existing keys use the cached value:
+    @test get!(()->10, cache, 1) == 2
+    @test get!(()->10, cache, 2) == 3
+    # New keys use the newly provided value:
+    @test get!(()->10, cache, 3) == 10
+end
+
 
 

--- a/test/MultiThreadedCaches.jl
+++ b/test/MultiThreadedCaches.jl
@@ -2,14 +2,69 @@ using MultiThreadedCaches
 
 using Test
 
-@testset "basics" begin
+@info "Testing with:" Threads.nthreads()
 
+@testset "basics" begin
     cache = MultiThreadedCache{Int,Int}()
     init_cache!(cache)
 
     @test length(cache.thread_caches) == Threads.nthreads()
 
+    get!(cache, 1) do
+        return 10
+    end
 
+    # The second get!() shouldn't have any effect, and the result should still be 10.
+    @test get!(cache, 1) do
+        return 100
+    end == 10
 
+    # Even on different threads, the cache should still have a value for key `1`.
+    @sync for i in 1:100
+        Threads.@spawn begin
+            @test get!(cache, 1) do
+                return 100
+            end == 10
+        end
+    end
 end
+
+# Helper function for stress-test: returns true if all elements in iterable `v` are equal.
+function all_equal(v)
+    length(v) < 2 && return true
+    e1 = first(v)
+    i = 2
+    @inbounds for i=2:length(v)
+        v[i] == e1 || return false
+    end
+    return true
+end
+
+@testset "stress-test" begin
+    cache = MultiThreadedCache{Int,Int}()
+    init_cache!(cache)
+
+    len = 100
+    outputs = [Channel{Int}(Inf) for _ in 1:len]
+
+    @sync for i in 1:100_000
+        Threads.@spawn begin
+            key = rand(1:len)
+            value = get!(cache, len) do
+                # Randomize a value for (key,value) the *first time* it's requested
+                rand(Int)
+            end
+            # Every subsequent get!() on the cache should see the exact same value,
+            # even if requested in parallel from multiple threads.
+            put!(outputs[key], value)
+        end
+    end
+
+    for ch in outputs
+        close(ch)
+        @test all_equal(collect(ch))
+    end
+end
+
+
 

--- a/test/MultiThreadedCaches.jl
+++ b/test/MultiThreadedCaches.jl
@@ -27,6 +27,9 @@ using Test
             end == 10
         end
     end
+
+    # Internals test:
+    @test length(cache.base_cache_futures) == 0
 end
 
 # Helper function for stress-test: returns true if all elements in iterable `v` are equal.
@@ -64,6 +67,9 @@ end
         close(ch)
         @test all_equal(collect(ch))
     end
+
+    # Internals test:
+    @test length(cache.base_cache_futures) == 0
 end
 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,0 +1,5 @@
+using Test
+
+@testset "MultiThreadedCaches.jl" begin
+    include("MultiThreadedCaches.jl")
+end


### PR DESCRIPTION
Implements a MultiThreadedCache{K,V}, and adds stress test.

This cache has no locks on access, and only has contention on a cache
miss. It only ever holds a shared lock for a constant-time duration,
never while executing user code. A Task requesting a key that is
already being computed on another Task will block while that computation
is being performed. By taking advantage of the append-only properties of
a cache, the cache can be duplicated per-Thread, to avoid locking in the
common case.

This PR adds:
- implementation
- tests
- CI configuration

