### PR TITLE
Concurrency safety fixes

### DIFF
--- a/src/MultiThreadedCaches.jl
+++ b/src/MultiThreadedCaches.jl
@@ -151,7 +151,9 @@ function Base.get!(func::Base.Callable, cache::MultiThreadedCache{K,V}, key) whe
                 e isa Exception || (e = ErrorException("Non-exception object thrown during get!(): $e"))
                 close(future, e)
                 # As below, the future isn't needed after this returns (see below).
-                delete!(cache.base_cache_futures, key)
+                @lock cache.base_cache_lock begin
+                    delete!(cache.base_cache_futures, key)
+                end
                 rethrow(e)
             end
             # Finally, lock again for a *constant time* to insert the computed value into


### PR DESCRIPTION
- Fix thread-safety violation by accidentally not locking the base cache during delete!
- Fix concurrency-safety by not holding the get!() on the thread-local cache across the whole execution
- Use per-thread locks to make invariant to Task migration. ...... In retrospect, this does make this whole structure start to look a lot like a Dict + a Read/Write lock, and I wonder how their performance would compare......

Actually, this didn't seem to have too much perf impact, which is nice:
```
┌ Info: benchmark results
│   Threads.nthreads() = 1
│   time_serial = 0.03260747
│   time_parallel = 0.152217246
└   time_baseline = 0.131397639
```

```
┌ Info: benchmark results
│   Threads.nthreads() = 20
│   time_serial = 0.030174521
│   time_parallel = 0.307062643
└   time_baseline = 1.239406026
```

```
┌ Info: benchmark results
│   Threads.nthreads() = 100
│   time_serial = 0.030373533
│   time_parallel = 1.771401144
└   time_baseline = 5.397114559
```