### PR TITLE
Fix data races in lazy construction and show() 

### DIFF
--- a/src/MultiThreadedCaches.jl
+++ b/src/MultiThreadedCaches.jl
@@ -185,10 +185,10 @@ function Base.get!(func::Base.Callable, cache::MultiThreadedCache{K,V}, key) whe
         Base.@lock tlock begin
             if test_haskey
                 if !haskey(tcache, key)
-                    setindex!(tcache, key, v)
+                    tcache[key] = v
                 end
             else
-                setindex!(tcache, key, v)
+                tcache[key] = v
             end
         end
     end

--- a/test/MultiThreadedCaches.jl
+++ b/test/MultiThreadedCaches.jl
@@ -123,7 +123,9 @@ end
 
 @testset "show" begin
     cache = MultiThreadedCache{Int64, Int64}()
+    # Exercise both show functions
     show(cache)
+    display(cache)
 end
 
 

--- a/test/MultiThreadedCaches.jl
+++ b/test/MultiThreadedCaches.jl
@@ -121,6 +121,10 @@ end
     @test cache.base_cache == Dict(1=>10)
 end
 
+@testset "show" begin
+    cache = MultiThreadedCache{Int64, Int64}()
+    show(cache)
+end
 
 
 

--- a/test/MultiThreadedCaches.jl
+++ b/test/MultiThreadedCaches.jl
@@ -31,6 +31,20 @@ using Test
     # Internals test:
     @test length(cache.base_cache_futures) == 0
 end
+@testset "KV types" begin
+    cache = MultiThreadedCache{Int,String}()
+    init_cache!(cache)
+
+    @test get!(()->"hi", cache, 1) == "hi"
+    @test get!(()->"bye", cache, 1) == "hi"
+
+    cache = MultiThreadedCache{Any,Any}()
+    init_cache!(cache)
+
+    @test get!(()->"hi", cache, 1) == "hi"
+    @test get!(()->2.0, cache, 1) == "hi"
+    @test get!(()->3.0, cache, 1.0) == "hi"
+end
 
 # Helper function for stress-test: returns true if all elements in iterable `v` are equal.
 function all_equal(v)


### PR DESCRIPTION
Need to always lock accesses to base_cache :)

- Forgot to lock during lazy construction in thread_cache(tid)
- Added a lock+copy to show(), to avoid holding the lock while printing
  to IO, which may block arbitrarily long
    - Perf improvement for Base.show: print to buffer instead of copy