### PR TITLE
Perf optimization: Eliminate allocations from cache-hit case.

### DIFF
--- a/src/MultiThreadedCaches.jl
+++ b/src/MultiThreadedCaches.jl
@@ -153,11 +153,11 @@ function Base.get!(func::Base.Callable, cache::MultiThreadedCache{K,V}, key) whe
             return value_or_miss::V
         end
         future_or_miss = get(cache.base_cache_futures, key, CACHE_MISS)
-        future::Channel{V} = if future_or_miss === CACHE_MISS
+        future = if future_or_miss === CACHE_MISS
             is_first_task = true
             ch = Channel{V}(1)
             cache.base_cache_futures[key] = ch
-            ch
+            ch::Channel{V}
         else
             future_or_miss::Channel{V}
         end

--- a/test/MultiThreadedCaches.jl
+++ b/test/MultiThreadedCaches.jl
@@ -143,6 +143,23 @@ end
     display(cache)
 end
 
+populate!(c,x) = get!(c, x) do
+    UInt64(2)
+end
+
+@testset "no allocations for cache-hit" begin
+    cache = MultiThreadedCache{Int64, Int64}()
+    init_cache!(cache)
+
+    # Populate the cache
+    populate!(cache, 10)
+
+    @test @allocated(populate!(cache, 10)) == 0
+    @test @allocated(populate!(cache, 10)) == 0
+
+    populate!(cache, 11)
+    @test @allocated(populate!(cache, 11)) == 0
+end
 
 
 

--- a/test/MultiThreadedCaches.jl
+++ b/test/MultiThreadedCaches.jl
@@ -120,7 +120,8 @@ end
 
     # Test that all Tasks saw the same exception thrown.
     close(exceptions)
-    @test all_equal(collect(exceptions))
+    output = collect(exceptions)
+    @test all_equal(output)
 
     # Test that after throwing an exception during a get! function, the cache is still
     # robust and working as intended.


### PR DESCRIPTION
- Outline a nested function that was being allocated as a closure.
- Convert a get! + do-closure to a get() with MISS default value, to prevent the side-effect `is_first_task` variable from being Boxed.

Before:
```julia
julia> using MultiThreadedCaches, BenchmarkTools

julia> c = MultiThreadedCache{Int,UInt64}()
MultiThreadedCache{Int64, UInt64}(Dict{Int64, UInt64}())

julia> init_cache!(c)
MultiThreadedCache{Int64, UInt64}(Dict{Int64, UInt64}())

julia> foo(c,x) = get!(c, x) do
           UInt64(2)
       end
foo (generic function with 1 method)

julia> @btime foo($c, $10)
  88.013 ns (1 allocation: 16 bytes)
0x0000000000000002
```
After:
```julia
julia> @btime foo($c, $10)
  75.891 ns (0 allocations: 0 bytes)
0x0000000000000002
```