### PR TITLE
Force specialization on `func::F`

### DIFF
--- a/src/MultiThreadedCaches.jl
+++ b/src/MultiThreadedCaches.jl
@@ -120,7 +120,7 @@ end
 
 const CACHE_MISS = :__MultiThreadedCaches_key_not_found__
 
-function Base.get!(func, cache::MultiThreadedCache{K,V}, key) where {K,V}
+function Base.get!(func::F, cache::MultiThreadedCache{K,V}, key) where {F,K,V}
     # If the thread-local cache has the value, we can return immediately.
     # We store tcache in a local variable, so that even if the Task migrates Threads, we are
     # still operating on the same initial cache object.


### PR DESCRIPTION
by default Julia does not specialize on this, this can be performance-critical in some cases.