### PR TITLE
Specify that the first argument to `get!(func, ::MultiThreadedCache, key)` is `Base.Callable`.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MultiThreadedCaches"
 uuid = "18056a9e-ed0c-4ef3-9ad7-376a7fb08032"
 authors = ["Nathan Daly <nhdaly@gmail.com> and contributors"]
-version = "0.1.3"
+version = "0.1.4"
 
 [compat]
 julia = "1.3"

--- a/src/MultiThreadedCaches.jl
+++ b/src/MultiThreadedCaches.jl
@@ -120,7 +120,7 @@ end
 
 const CACHE_MISS = :__MultiThreadedCaches_key_not_found__
 
-function Base.get!(func, cache::MultiThreadedCache{K,V}, key) where {K,V}
+function Base.get!(func::Base.Callable, cache::MultiThreadedCache{K,V}, key) where {K,V}
     # If the thread-local cache has the value, we can return immediately.
     # We store tcache in a local variable, so that even if the Task migrates Threads, we are
     # still operating on the same initial cache object.


### PR DESCRIPTION
Thus avoiding Aqua ambiguities with `get(t::AbstractDict, key, default)`.

Increment the minor version number.