### PR TITLE
Don't use a symbol for the never-cached value

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MultiThreadedCaches"
 uuid = "18056a9e-ed0c-4ef3-9ad7-376a7fb08032"
 authors = ["Nathan Daly <nhdaly@gmail.com> and contributors"]
-version = "0.1.4"
+version = "0.1.5"
 
 [compat]
 julia = "1.3"

--- a/src/MultiThreadedCaches.jl
+++ b/src/MultiThreadedCaches.jl
@@ -118,7 +118,8 @@ function _thread_lock(cache::MultiThreadedCache, tid)
 end
 
 
-const CACHE_MISS = :__MultiThreadedCaches_key_not_found__
+struct NeverCached end
+const CACHE_MISS = NeverCached()
 
 function Base.get!(func::Base.Callable, cache::MultiThreadedCache{K,V}, key) where {K,V}
     # If the thread-local cache has the value, we can return immediately.


### PR DESCRIPTION
Use an internal singleton value, so that if the user has some reason to make a `MultiThreadedCache{K, Symbol}` they won't get strange behavior if they happen to store `:__MultiThreadedCaches_key_not_found__`.

In particular this could happen in the original code:
```
julia> c=MultiThreadedCache{Int, Symbol}()
MultiThreadedCache{Int64, Symbol}(Dict{Int64, Symbol}())

julia> MultiThreadedCaches.init_cache!(c)
MultiThreadedCache{Int64, Symbol}(Dict{Int64, Symbol}())

julia> get!(c, 4) do; :__MultiThreadedCaches_key_not_found__ end
:__MultiThreadedCaches_key_not_found__

julia> get!(c, 4) do; :hello end
:hello
```
where we didn't expect to get `:hello` on the second `get!`.